### PR TITLE
Fix issue with extra "\\ " in mount command

### DIFF
--- a/onedrive.j2
+++ b/onedrive.j2
@@ -49,7 +49,7 @@ ExecStart=/usr/bin/rclone mount \
     --vfs-cache-mode=full \
     --vfs-cache-poll-interval={{ rclone_vfs_cache_poll_interval }} \
     --vfs-fast-fingerprint \
-    --vfs-disk-space-total-size=25000G \ {# Set it to your Onedrive storage size or delete #}
+    --vfs-disk-space-total-size=25000G \
     --vfs-read-ahead=128M \
 {% endif %}
     --vfs-read-chunk-size-limit=2G \


### PR DESCRIPTION
Had to remove comment as it caused issue with rclone mount
```
Command mount needs 2 arguments maximum: you provided 3 non flag arguments: ["\\ "....
```